### PR TITLE
RF: Allow Redis to connect via TLS

### DIFF
--- a/etelemetry_app/server/connections.py
+++ b/etelemetry_app/server/connections.py
@@ -5,7 +5,6 @@ import os
 import aiohttp
 import asyncpg
 import redis.asyncio as redis
-from urllib.parse import urlparse
 
 try:  # do not define unless necessary, to avoid overwriting established sessions
     MEM_CACHE


### PR DESCRIPTION
Since Heroku Redis uses self-signed certificates, allow loose certificate restrictions.